### PR TITLE
Add configuration to cross-compile with cross

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -65,7 +65,7 @@ rand = "0.9.2"
 pretty-hex = "0.4.1"
 terminal_size = "0.4.3"
 octocrab = "0.48.1"
-reqwest = "0.12.24"
+reqwest = { version="0.12.24", default-features = false, features = ["rustls-tls", "json"]}
 zip = "6.0.0"
 byteorder = "1.5.0"
 hex = "0.4.3"

--- a/Cross.toml
+++ b/Cross.toml
@@ -1,0 +1,5 @@
+[build]
+pre-build = [                                  # Install cross-compilation lib dependencies
+    "dpkg --add-architecture $CROSS_DEB_ARCH", 
+    "apt-get update && apt-get --assume-yes install libudev-dev:$CROSS_DEB_ARCH"
+]                 

--- a/README.md
+++ b/README.md
@@ -108,3 +108,20 @@ For example:
 ```text
 cargo run -- select
 ```
+
+### Cross compilation
+
+Compilation for linux on other platform is possible using the [cross](https://github.com/cross-rs/cross) tool.
+
+It requires both `cross` and [`docker` or `podman`] to be installed.
+
+```bash
+# Install podman or docker ...
+# To install cross
+cargo install cross
+
+# To compile for ARM64
+cross build --target aarch64-unknown-linux-gnu
+
+# The resulting executable is now in ./target/aarch64-unknown-linux-gnu/debug/cfcli
+```


### PR DESCRIPTION
Allows to use the cross tool to cross-compile.

This configuration should only work for linux. Tested on aarch64.