### PR TITLE
Update to crazyflie-lib 0.8.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -417,7 +417,7 @@ dependencies = [
  "confy",
  "crazyflie-lib",
  "crazyflie-link",
- "crazyradio 0.6.0",
+ "crazyradio 0.7.0",
  "env_logger",
  "flume",
  "futures",
@@ -712,9 +712,9 @@ dependencies = [
 
 [[package]]
 name = "crazyflie-lib"
-version = "0.7.1"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69d54f64d51934a7f2941df5f98efb858fb68ed1e075c1b6f164e50598825279"
+checksum = "63e1924ed55c8ef67ed9bf2561f2cc7aca148802f9c1ddf6a469bbaadba592ec"
 dependencies = [
  "async-broadcast",
  "async-stream",
@@ -735,13 +735,13 @@ dependencies = [
 
 [[package]]
 name = "crazyflie-link"
-version = "0.4.3"
+version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c546b30f976817451936078445d21d5efecbe2033fc3ea25e8fac99d37e733d9"
+checksum = "899dd3e14b47a1be3ee0c78c34c5b4b6634899ea2f5aab4d033829dd3d3ff3f0"
 dependencies = [
  "async-trait",
  "bitflags 2.11.0",
- "crazyradio 0.6.0",
+ "crazyradio 0.7.0",
  "flume",
  "futures",
  "futures-channel",
@@ -768,9 +768,9 @@ dependencies = [
 
 [[package]]
 name = "crazyradio"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fb0ef9ca124036f6ae818da8529ce53da1bae563b88fc3ca847c78c6258bb989"
+checksum = "bf6b691de0b51316a0a78f351fd1b727e1242513b6a5eaab2284b153e4690a43"
 dependencies = [
  "flume",
  "rusb",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,9 +57,9 @@ num_enum = "0.7.4"
 half = "2.6.0"
 env_logger = "0.11.8"
 anyhow = "1.0"
-crazyflie-link = { version = "0.4.2", default-features = false }
-crazyflie-lib = { version = "0.7.1", default-features = false }
-crazyradio = { version = "0.6.0", features = ["async"] }
+crazyflie-link = { version = "0.5.0", default-features = false }
+crazyflie-lib = { version = "0.8.0", default-features = false }
+crazyradio = { version = "0.7.0", features = ["async"] }
 rusb = "0.9"
 cfloader = "0.1.0"
 clap = { version = "4.5.46", features = ["derive"] }
@@ -87,8 +87,8 @@ hex = "0.4.3"
 chrono = "0.4.44"
 
 [target.'cfg(unix)'.dependencies]
-crazyflie-link = { version = "0.4.2", default-features = false, features = ["packet_capture"] }
-crazyradio = { version = "0.6.0", features = ["async", "packet_capture"] }
+crazyflie-link = { version = "0.5.0", default-features = false, features = ["packet_capture"] }
+crazyradio = { version = "0.7.0", features = ["async", "packet_capture"] }
 
 # Used by build.rs to generate shell-completion scripts from the same clap
 # command tree as the binary (src/cli.rs is shared via include!).

--- a/src/modules/bootloader.rs
+++ b/src/modules/bootloader.rs
@@ -513,38 +513,6 @@ pub async fn flash(link_context: &crazyflie_link::LinkContext, uri: &str, toc_ca
 
       let memories = cf.memory.get_memories(Some(MemoryType::DeckMemory));
       if !memories.is_empty() {
-        // Write the new-fw-size to the deck's command region before the
-        // bulk write so the deck-side driver can erase the right region
-        // up front. The DeckMemorySection abstraction doesn't expose the
-        // command/info addresses, so do this via RawMemory: parse the
-        // info section to locate the protocol section index by name,
-        // then write 4 LE bytes at 0x1000 + idx*0x20.
-        let raw = match cf.memory.open_memory::<RawMemory>(memories[0].clone()).await {
-          Some(Ok(r)) => r,
-          Some(Err(e)) => return Err(anyhow!("Open DeckMemory as raw: {:?}", e)),
-          None => return Err(anyhow!("DeckMemory not found")),
-        };
-        let mut proto_idx: Option<usize> = None;
-        for i in 0..8usize {
-          let data = raw.read(1 + i * 0x20, 0x20).await?;
-          if data.len() < 0x20 { break; }
-          if (data[0] & 0x01) == 0 { continue; }
-          let name: String = data[14..32].iter()
-              .take_while(|&&b| b != 0)
-              .map(|&b| b as char)
-              .collect();
-          if name == firmware.target {
-            proto_idx = Some(i);
-            break;
-          }
-        }
-        if let Some(idx) = proto_idx {
-          let cmd_addr = 0x1000 + idx * 0x20;
-          let size_bytes = (firmware.data.len() as u32).to_le_bytes();
-          raw.write(cmd_addr, &size_bytes).await?;
-        }
-        cf.memory.close_memory(raw).await?;
-
         let deck_memory = match cf.memory.open_memory::<DeckMemory>(memories[0].clone()).await {
           Some(Ok(deck)) => deck,
           Some(Err(e)) => {
@@ -584,7 +552,7 @@ pub async fn flash(link_context: &crazyflie_link::LinkContext, uri: &str, toc_ca
           let progress_callback = move |bytes_written: usize, _total_bytes: usize| {
             pb.set_position(bytes_written as u64);
           };
-          section.write_with_progress(0, &firmware.data, progress_callback).await?;
+          section.flash_firmware_with_progress(&firmware.data, progress_callback).await?;
           finish_progress(&progress_bar, "Deck firmware flashed successfully!");
         }
 


### PR DESCRIPTION
Bumps crazyflie-link to 0.5.0 and crazyradio to 0.7.0 to match. Switches deck flashing to the public flash_firmware_with_progress API, which now writes the new-firmware-size internally so the manual RawMemory pre-write is removed.