### PR TITLE
Use crazyflie-link and crazyradio through the crazyflie-lib re-exports

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -412,7 +412,7 @@ dependencies = [
 
 [[package]]
 name = "cfcli"
-version = "0.11.1"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-stream",
@@ -425,8 +425,6 @@ dependencies = [
  "colored",
  "confy",
  "crazyflie-lib",
- "crazyflie-link",
- "crazyradio 0.7.0",
  "env_logger",
  "flume",
  "futures",
@@ -721,9 +719,9 @@ dependencies = [
 
 [[package]]
 name = "crazyflie-lib"
-version = "0.8.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "63e1924ed55c8ef67ed9bf2561f2cc7aca148802f9c1ddf6a469bbaadba592ec"
+checksum = "d127ba8e761396daa5b623b631d786c6aef3372443292813d4d067209b5f1013"
 dependencies = [
  "async-broadcast",
  "async-stream",
@@ -744,9 +742,9 @@ dependencies = [
 
 [[package]]
 name = "crazyflie-link"
-version = "0.5.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899dd3e14b47a1be3ee0c78c34c5b4b6634899ea2f5aab4d033829dd3d3ff3f0"
+checksum = "51c777bf6ea26a601a31642c2cab2500e099772e59b57b98a70fdfe1ea5e159e"
 dependencies = [
  "async-trait",
  "bitflags 2.11.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -57,9 +57,7 @@ num_enum = "0.7.4"
 half = "2.6.0"
 env_logger = "0.11.8"
 anyhow = "1.0"
-crazyflie-link = { version = "0.5.0", default-features = false }
-crazyflie-lib = { version = "0.8.0", default-features = false }
-crazyradio = { version = "0.7.0", features = ["async"] }
+crazyflie-lib = "0.8.1"
 rusb = "0.9"
 cfloader = "0.1.0"
 clap = { version = "4.5.46", features = ["derive"] }
@@ -87,8 +85,7 @@ hex = "0.4.3"
 chrono = "0.4.44"
 
 [target.'cfg(unix)'.dependencies]
-crazyflie-link = { version = "0.5.0", default-features = false, features = ["packet_capture"] }
-crazyradio = { version = "0.7.0", features = ["async", "packet_capture"] }
+crazyflie-lib = { version = "0.8.1", features = ["packet_capture"] }
 
 # Used by build.rs to generate shell-completion scripts from the same clap
 # command tree as the binary (src/cli.rs is shared via include!).

--- a/src/main.rs
+++ b/src/main.rs
@@ -311,7 +311,7 @@ fn is_streaming_command(cmd: &Commands) -> bool {
 /// alongside other immutable accesses to `holder`.
 async fn connect_cf<'a>(
     holder: &'a mut Option<crazyflie_lib::Crazyflie>,
-    link_context: &crazyflie_link::LinkContext,
+    link_context: &crazyflie_lib::crazyflie_link::LinkContext,
     uri: &str,
     toc_cache: ConfigTocCache,
     measure_connect_time: bool,
@@ -545,9 +545,9 @@ async fn run() -> Result<()> {
     let toc_cache = ConfigTocCache::new(config.clone(), args.no_toc_cache);
 
     #[cfg(all(unix, feature = "packet_capture"))]
-    crazyflie_link::capture::init();
+    crazyflie_lib::crazyflie_link::capture::init();
 
-    let link_context = crazyflie_link::LinkContext::new();
+    let link_context = crazyflie_lib::crazyflie_link::LinkContext::new();
 
     let mut connected_cf: Option<crazyflie_lib::Crazyflie> = None;
     let preserve_console = args.preserve_console;

--- a/src/main.rs
+++ b/src/main.rs
@@ -1280,12 +1280,12 @@ async fn run() -> Result<()> {
             match command {
                 HlCommands::Arm => {
                     println!("Arming Crazyflie...");
-                    cf.platform.send_arming_request(true).await?;
+                    cf.supervisor.send_arming_request(true).await?;
                     println!("Crazyflie armed!");
                 }
                 HlCommands::Disarm => {
                     println!("Disarming Crazyflie...");
-                    cf.platform.send_arming_request(false).await?;
+                    cf.supervisor.send_arming_request(false).await?;
                     println!("Crazyflie disarmed!");
                 }
                 HlCommands::Takeoff(params) => {

--- a/src/modules/bootloader.rs
+++ b/src/modules/bootloader.rs
@@ -2,7 +2,7 @@ use anyhow::{anyhow, bail, Result};
 use crazyflie_lib::Crazyflie;
 use crazyflie_lib::subsystems::memory::{DeckMemory, MemoryType, RawMemory};
 use tokio::time::{sleep, timeout, Duration};
-use crazyflie_link::{Connection, LinkContext, Packet};
+use crazyflie_lib::crazyflie_link::{Connection, LinkContext, Packet};
 use byteorder::{LittleEndian, ByteOrder};
 
 use crate::ConfigTocCache;
@@ -238,7 +238,7 @@ fn print_target_info(name: &str, info: &BootloaderInfo) {
   println!("  CPU ID: 0x{:04X}", info.cpuid);
 }
 
-pub async fn print_bootloader_info(link_context: &crazyflie_link::LinkContext, cold: bool, uri: &str) -> Result<()> {
+pub async fn print_bootloader_info(link_context: &crazyflie_lib::crazyflie_link::LinkContext, cold: bool, uri: &str) -> Result<()> {
 
   let link = start_bootloader(link_context, cold, uri).await?;
 
@@ -258,7 +258,7 @@ pub async fn print_bootloader_info(link_context: &crazyflie_link::LinkContext, c
   Ok(())
 }
 
-pub async fn reboot(link_context: &crazyflie_link::LinkContext, uri: &str,) -> Result<()> {
+pub async fn reboot(link_context: &crazyflie_lib::crazyflie_link::LinkContext, uri: &str,) -> Result<()> {
 
   let link = link_context.open_link(uri).await?;
   send_command(&link, BootloaderCommand::ResetInit, None).await?;
@@ -420,7 +420,7 @@ async fn flash_deck_ctrl(
     Ok(())
 }
 
-pub async fn flash(link_context: &crazyflie_link::LinkContext, uri: &str, toc_cache: ConfigTocCache, firmware_upgrade: FirmwareUpgrade, cold: bool) -> Result<()> {
+pub async fn flash(link_context: &crazyflie_lib::crazyflie_link::LinkContext, uri: &str, toc_cache: ConfigTocCache, firmware_upgrade: FirmwareUpgrade, cold: bool) -> Result<()> {
 
   let firmware_for_bootloader = firmware_upgrade.get_firmware_for_bootloader();
   let firmware_for_deckctrl = firmware_upgrade.get_firmware_for_deckctrl();

--- a/src/modules/crazyradio.rs
+++ b/src/modules/crazyradio.rs
@@ -1,5 +1,5 @@
 use anyhow::{bail, Result};
-use crazyradio::{Channel, Crazyradio, Datarate};
+use crazyflie_lib::crazyflie_link::crazyradio::{Channel, Crazyradio, Datarate};
 use std::time::Duration;
 
 const CRAZYRADIO_VID: u16 = 0x1915;

--- a/src/modules/test.rs
+++ b/src/modules/test.rs
@@ -22,7 +22,7 @@ pub trait StabilityTest {
     
     fn run<'a>(
         &'a self,
-        link_context: &'a crazyflie_link::LinkContext,
+        link_context: &'a crazyflie_lib::crazyflie_link::LinkContext,
         uri: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>>;
 }
@@ -37,7 +37,7 @@ impl StabilityTest for ReconnectTest {
     
     fn run<'a>(
         &'a self,
-        link_context: &'a crazyflie_link::LinkContext,
+        link_context: &'a crazyflie_lib::crazyflie_link::LinkContext,
         uri: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>> {
         Box::pin(async move {
@@ -58,7 +58,7 @@ impl StabilityTest for ParamReadReadWriteTest {
     
     fn run<'a>(
         &'a self,
-        link_context: &'a crazyflie_link::LinkContext,
+        link_context: &'a crazyflie_lib::crazyflie_link::LinkContext,
         uri: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>> {
         Box::pin(async move {
@@ -98,7 +98,7 @@ impl StabilityTest for LoggingTest {
     
     fn run<'a>(
         &'a self,
-        link_context: &'a crazyflie_link::LinkContext,
+        link_context: &'a crazyflie_lib::crazyflie_link::LinkContext,
         uri: &'a str,
     ) -> Pin<Box<dyn Future<Output = Result<()>> + Send + 'a>> {
         Box::pin(async move {
@@ -134,7 +134,7 @@ impl StabilityTest for LoggingTest {
 }
 
 pub async fn stability(
-    link_context: &crazyflie_link::LinkContext,
+    link_context: &crazyflie_lib::crazyflie_link::LinkContext,
     uri: &str,
     iterations: u32,
 ) -> Result<()> {
@@ -148,7 +148,7 @@ pub async fn stability(
 }
 
 async fn run_stability_tests(
-    link_context: &crazyflie_link::LinkContext,
+    link_context: &crazyflie_lib::crazyflie_link::LinkContext,
     uri: &str,
     iterations: u32,
     tests: Vec<Box<dyn StabilityTest>>,
@@ -213,7 +213,7 @@ struct RebootTestResult {
 }
 
 pub async fn reboot(
-    link_context: &crazyflie_link::LinkContext,
+    link_context: &crazyflie_lib::crazyflie_link::LinkContext,
     uri: &str,
     toc_cache: ConfigTocCache,
     iterations: u32,


### PR DESCRIPTION
crazyflie-lib 0.8.1 re-exports crazyflie-link, which re-exports crazyradio, so the exact versions the lib was built against are reachable as crazyflie_lib::crazyflie_link and no longer need to be direct dependencies kept manually in sync. The packet_capture feature is enabled through the new crazyflie-lib passthrough feature, still for Unix targets only.

Also routes the two arming requests through the supervisor subsystem: 0.8.1 deprecates Platform::send_arming_request in favor of the functionally identical Supervisor::send_arming_request (same packet on the wire). Note that arming is still under "high level commander" functionality which it is unrelated to imo.

No CLI or behavior changes. Verified with cargo check with and without default features, zero warnings.